### PR TITLE
test: mock Next.js and Supabase APIs in course tests

### DIFF
--- a/__tests__/api/admin/courses.test.ts
+++ b/__tests__/api/admin/courses.test.ts
@@ -6,6 +6,20 @@ vi.mock("@/lib/supabase", () => ({
   getSupabaseAdmin: vi.fn(),
 }));
 
+// Mock Next.js request-scoped APIs that aren't available in vitest
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({ getAll: () => [], set: vi.fn() }),
+}));
+
+// Mock the Supabase SSR client so getSessionUser() returns a fake authenticated user
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(() => ({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: "test-user" } } }),
+    },
+  })),
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,15 +1,19 @@
 import { defineConfig } from "vitest/config";
+import { configDefaults } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
     environment: "node",
+    exclude: [...configDefaults.exclude, "e2e/**"],
     // Provide dummy env vars so modules that read them at import time don't throw
     env: {
       NEXT_PUBLIC_SUPABASE_URL: "http://localhost:54321",
       NEXT_PUBLIC_SUPABASE_ANON_KEY: "test-anon-key",
       SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+      EMAIL_SMTP_HOST: "127.0.0.1",
+      EMAIL_SMTP_PORT: "54325",
     },
   },
 });


### PR DESCRIPTION
Mock next/headers and Supabase SSR client in courses test to
simulate authenticated user and cookie APIs. Update vitest config
to exclude e2e tests and add dummy email env vars for more
realistic test environments. These changes allow tests to run in
Vitest without relying on unavailable Next.js APIs and ensure
authenticated flows are covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup for course admin functionality with authentication and cookie handling capabilities.

* **Chores**
  * Updated test configuration to exclude end-to-end tests from standard test runs.
  * Added environment variables for email service configuration in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->